### PR TITLE
fix: find tsconfig

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -299,7 +299,7 @@ module.exports = {
         curly: ['error', 'all'],
       },
       parserOptions: {
-        project: 'tsconfig.json',
+        project: '**/tsconfig.json',
       },
       settings: {
         'import/resolver': {


### PR DESCRIPTION
In monorepo, when lacking of `tsconfig.js` in repo's root, can see error `Parsing error: Cannot read file '.../tsconfig.json'`

https://stackoverflow.com/a/69290802/14995215