### PR TITLE
feat(eslint-typescript): enable no-non-null-assertion rule

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -297,6 +297,11 @@ module.exports = {
         'no-restricted-imports': [...xo.rules['no-restricted-imports'], 'assert'],
         // https://github.com/prettier/eslint-config-prettier#curly
         curly: ['error', 'all'],
+        /**
+         * eslint-config-xo-typescript disabled this rule by default, need to enable it 
+         * https://github.com/xojs/eslint-config-xo-typescript/blob/main/index.js#L446
+         */
+        '@typescript-eslint/no-non-null-assertion': 'error'
       },
       parserOptions: {
         project: 'tsconfig.json',


### PR DESCRIPTION
Some how eslint-config-xo-typescript disabled this [rule](https://github.com/xojs/eslint-config-xo-typescript/blob/main/index.js#L446) by default, need to enable it 



[rule details](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-non-null-assertion.md)

@gao-sun @wangsijie cc: @IceHe @xiaoyijun @darcyYe 

