### PR TITLE
chore: fix eslint-disable rule configuration

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -189,12 +189,7 @@ const promiseRules = {
 
 /** @type {import('eslint').Linter.RulesRecord} **/
 const eslintCommentsRules = {
-  'eslint-comments/disable-enable-pair': [
-    'error',
-    {
-      allowWholeFile: true,
-    },
-  ],
+  'eslint-comments/disable-enable-pair': 'error',
   'eslint-comments/no-aggregating-enable': 'error',
   'eslint-comments/no-duplicate-disable': 'error',
 


### PR DESCRIPTION
## Summary
Per [slack discussion](https://silverhand-io.slack.com/archives/C02A8G4HVAM/p1639981870158400), globally disabling eslint rules in a file is not recommended and `eslint-disable` switch should work with following `eslint-enable`.

## Testing
Tested the configuration locally in repo logto/js.
![image](https://user-images.githubusercontent.com/15182327/146871318-7f12abc3-8f98-46bd-9cf5-698e9df7a260.png)
![image](https://user-images.githubusercontent.com/15182327/146871274-fadb19e9-786f-4a51-a789-8db91758024e.png)

The globally `eslint-disable` comments were marked as errors and this error can be fixed as long as corresponding `eslint-enable` rules were added in the file.
![image](https://user-images.githubusercontent.com/15182327/146871650-15bbaae7-106c-4a8d-b567-b6420d8ba2c8.png)
![image](https://user-images.githubusercontent.com/15182327/146871668-773e5436-9542-409b-8a55-ed1f99c8d97f.png)

This rule can also be fixed by breaking the global config into local configs.
![image](https://user-images.githubusercontent.com/15182327/146871874-adc84268-9e3c-4075-916a-283b7070be92.png)
![image](https://user-images.githubusercontent.com/15182327/146871844-f3ec7408-3353-42e5-9ad4-c19678f26aad.png)
