### PR TITLE
fix(eslint-config): fix padding line between statements rule

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -309,10 +309,14 @@ module.exports = {
          * https://github.com/xojs/eslint-config-xo-typescript/blob/main/index.js#L446
          */
         '@typescript-eslint/no-non-null-assertion': 'error',
-        "padding-line-between-statements": [
+        "padding-line-between-statements": "off",
+        "@typescript-eslint/padding-line-between-statements": [
           "error",
-          { "blankLine": "always", "prev": "*", "next": "block-like" },
-          { "blankLine": "always", "prev": "*", "next": "return" },
+          {
+            blankLine: "always",
+            prev: "*",
+            next: ["interface", "type", "block-like", "return"]
+          },
         ],
       },
       parserOptions: {


### PR DESCRIPTION
Use `@typescript-eslint/padding-line-between-statements` instead of the base eslint rule.
Now it will also add new line before typescript interfaces and types.