### PR TITLE
fix: bump typescript eslint plugins and disable unnecessary rules

### DIFF
--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -324,6 +324,22 @@ module.exports = {
          * eslint default should be min 2
          */
         'id-length': [2, { min: 2, exceptions: ['i', 'j', 'k', '_'], properties: 'never' }],
+        /**
+         * Override unnecessary naming limitation in typescript
+         * Config was introduced in eslint-config-xo-typescript v0.45.0
+         */
+        '@typescript-eslint/naming-convention': 'off',
+        /**
+         * Override the rule to allow explicit return arrows
+         * Config was introduced in eslint-config-xo v0.40.0
+        */
+        'object-shorthand': [
+          'error',
+          'always',
+          {
+            avoidExplicitReturnArrows: false,
+          },
+        ],
       },
       parserOptions: {
         project: '**/tsconfig.json',

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -32,8 +32,8 @@
   },
   "dependencies": {
     "@silverhand/eslint-plugin-fp": "^2.5.0",
-    "@typescript-eslint/eslint-plugin": "^5.6.0",
-    "@typescript-eslint/parser": "^5.6.0",
+    "@typescript-eslint/eslint-plugin": "^5.8.0",
+    "@typescript-eslint/parser": "^5.8.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-config-xo": "^0.40.0",
     "eslint-config-xo-typescript": "^0.50.0",


### PR DESCRIPTION
Fix eslint by bumping typescript-eslint plugin versions and override several unnecessary rules.
Target patch version: 0.9.1