### PR TITLE
fix(eslint-react): use `legacy` for `color-function-notation`

### DIFF
--- a/packages/eslint-config-react/.stylelintrc.json
+++ b/packages/eslint-config-react/.stylelintrc.json
@@ -3,6 +3,7 @@
   "rules": {
     "indentation": [2, { "baseIndentLevel": 1 }],
     "selector-class-pattern": "^((?!-).)*$",
-    "selector-id-pattern": "^((?!-).)*$"
+    "selector-id-pattern": "^((?!-).)*$",
+    "color-function-notation": "legacy"
   }
 }


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
disable the rule since parcel cannot recognize the modern notation

<img width="286" alt="image" src="https://user-images.githubusercontent.com/14722250/155662807-9c0c0d62-f54f-47f5-9645-9f092cb1aba6.png">
<img width="363" alt="image" src="https://user-images.githubusercontent.com/14722250/155662831-6c116cd5-e5ae-4448-9aae-4560c6a6c1ed.png">


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
tested in project