### PR TITLE
fix(eslint-react): update `react/jsx-curly-brace-presence`

### DIFF
--- a/packages/eslint-config-react/index.js
+++ b/packages/eslint-config-react/index.js
@@ -13,5 +13,11 @@ module.exports = {
     // https://github.com/prettier/eslint-config-prettier#curly
     curly: ['error', 'all'],
     'unicorn/prevent-abbreviations': ['error', { replacements }],
+    // Override this one since TypeScript does not recognize `propElementValues` w/o curly
+    'react/jsx-curly-brace-presence': [
+      'error',
+      { props: 'never', children: 'never', propElementValues: 'always' },
+    ],
   },
 };
+/* eslint-enable unicorn/prefer-module */


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
update the rule since TypeScript / VSCode won't recognize

with default rule in `xo-react`:

<img width="361" alt="image" src="https://user-images.githubusercontent.com/14722250/155965156-e4b3afe6-c15e-4eff-ab67-af7017ec1a7f.png">

with this override:

<img width="386" alt="image" src="https://user-images.githubusercontent.com/14722250/155965194-867d3077-cd60-4a2d-819d-f53ea0bd7a48.png">

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

in VSCode
