### PR TITLE
feat(eslint-react): allow double exclamation marks in react tsx

### DIFF
--- a/packages/eslint-config-react/index.js
+++ b/packages/eslint-config-react/index.js
@@ -22,6 +22,7 @@ module.exports = {
             checkArguments: false,
           },
         ],
+        'no-implicit-coercion': ['error', { allow: ['!!'] }],
       },
     },
   ],


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Update eslint-react to allow `!!` in React tsx files.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
[LOG-2052](https://linear.app/silverhand/issue/LOG-2052/allow-value-type-conversion-and-ref-abbreviation-in-react-eslint)

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Tested in logto console package.json first, and it worked as expected
