### PR TITLE
feat(react-eslint): allow 'ref' abbreviation in React

### DIFF
--- a/packages/eslint-config-react/replacements.js
+++ b/packages/eslint-config-react/replacements.js
@@ -5,4 +5,6 @@ module.exports = {
   ...replacements,
   src: false,
   props: false,
+  ref: false,
 };
+/* eslint-enable unicorn/prefer-module */


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Update eslint-react to allow `ref` abbreviation in React project

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->
[LOG-2052](https://linear.app/silverhand/issue/LOG-2052/allow-value-type-conversion-and-ref-abbreviation-in-react-eslint)

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
