### PR TITLE
fix(eslint-config): remove typescript from eslint-config peer dependencies

### DIFF
--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -51,8 +51,7 @@
   },
   "peerDependencies": {
     "eslint": "^8.1.0",
-    "prettier": "^2.3.2",
-    "typescript": "^4.3.5"
+    "prettier": "^2.3.2"
   },
   "engines": {
     "node": ">=14.15.0"


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Remove typescript from eslint-config peer dependencies list, as it might be used in a non-typescript project like `react-sample`.

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
