### PR TITLE
fix(eslint-config-react): disable 'node/file-extension-in-import' rule

### DIFF
--- a/packages/eslint-config-react/index.js
+++ b/packages/eslint-config-react/index.js
@@ -35,6 +35,15 @@ module.exports = {
       'error',
       { props: 'never', children: 'never', propElementValues: 'always' },
     ],
+    'node/file-extension-in-import': [
+      'error', 'always',
+      {
+        '.js': 'never',
+        '.jsx': 'never',
+        '.ts': 'never',
+        '.tsx': 'never',
+      }
+    ],
   },
 };
 /* eslint-enable unicorn/prefer-module */


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Disable `node/file-extension-in-import` rule for the following file extensions in `eslint-config-react`
* js
* jsx
* ts
* tsx

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
- [x] Tested locally