### PR TITLE
fix(config-react): ignore `global` for pseudo class

### DIFF
--- a/packages/eslint-config-react/.stylelintrc.json
+++ b/packages/eslint-config-react/.stylelintrc.json
@@ -4,6 +4,14 @@
     "indentation": [2, { "baseIndentLevel": 1 }],
     "selector-class-pattern": "^((?!-).)*$",
     "selector-id-pattern": "^((?!-).)*$",
-    "color-function-notation": "legacy"
+    "color-function-notation": "legacy",
+    "selector-pseudo-class-no-unknown": [
+      true,
+      {
+        "ignorePseudoClasses": [
+          "global"
+        ]
+      }
+    ]
   }
 }


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
ignore `global` in stylelint `selector-pseudo-class-no-unknown` rule to prevent false positive. extracted from `core/ui`.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
N/A
