### PR TITLE
fix(jest): update config to work with jest v29

### DIFF
--- a/packages/jest-config/jest.config.ts
+++ b/packages/jest-config/jest.config.ts
@@ -2,14 +2,8 @@ import type { Config } from '@jest/types';
 import deepmerge from 'deepmerge';
 
 const baseConfig: Config.InitialOptions = {
-  preset: 'ts-jest',
-  transform: {
-    // Enable JS/JSX transformation
-    '\\.(t|j)sx?$': 'ts-jest',
-  },
-  transformIgnorePatterns: [
-    '[/\\\\]node_modules[/\\\\]((?!(ky|nanoid|jose)[/\\\\]).)+\\.(js|jsx|mjs|cjs|ts|tsx)$',
-  ],
+  preset: 'ts-jest/presets/js-with-ts',
+  transformIgnorePatterns: ['node_modules/(?!(.*(nanoid|jose|ky))/)'],
   moduleNameMapper: {
     // Map path alias in `tsconfig.json`
     '^@/(.*)$': '<rootDir>/src/$1',


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->

jest v29 has some trouble with ESM in node_modues. will cause `SyntaxError: Cannot use import statement outside a module` again if not properly configured. this PR resolves the issue.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->

<img width="254" alt="image" src="https://user-images.githubusercontent.com/14722250/195762022-eb1599fc-314d-459c-bdf3-5c004c5b71f4.png">

also, only necessary files are transformed by ts-jest:

<img width="352" alt="image" src="https://user-images.githubusercontent.com/14722250/195762165-ea44d056-8041-4a55-a8f6-95e38d8b193a.png">

js files in other modules are not being transformed, e.g., i18next
