### PR TITLE
chore: update version bump configs

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -3,7 +3,7 @@
   "changelog": "@changesets/cli/changelog",
   "commit": false,
   "fixed": [],
-  "linked": [],
+  "linked": [["@silverhand/eslint-*"], ["@silverhand/ts-*"]],
   "access": "restricted",
   "baseBranch": "master",
   "updateInternalDependencies": "patch",

--- a/packages/eslint-config-react/package.json
+++ b/packages/eslint-config-react/package.json
@@ -25,7 +25,7 @@
     "url": "https://github.com/silverhand-io/configs/issues"
   },
   "dependencies": {
-    "@silverhand/eslint-config": "^1.2.0",
+    "@silverhand/eslint-config": "workspace:^",
     "eslint-config-xo-react": "^0.27.0",
     "eslint-plugin-jsx-a11y": "^6.6.1",
     "eslint-plugin-react": "^7.29.0",

--- a/packages/jest-config/package.json
+++ b/packages/jest-config/package.json
@@ -24,8 +24,8 @@
     "prepack": "pnpm build"
   },
   "devDependencies": {
-    "@silverhand/eslint-config": "^1.2.0",
-    "@silverhand/ts-config": "^1.2.1",
+    "@silverhand/eslint-config": "workspace:^",
+    "@silverhand/ts-config": "workspace:^",
     "@types/node": "16",
     "jest": "^29.0.0",
     "prettier": "^2.7.1",

--- a/packages/ts-config-react/package.json
+++ b/packages/ts-config-react/package.json
@@ -23,11 +23,11 @@
     "url": "https://github.com/silverhand-io/configs/issues"
   },
   "dependencies": {
-    "@silverhand/ts-config": "^1.2.1"
+    "@silverhand/ts-config": "workspace:^"
   },
   "devDependencies": {
-    "@silverhand/eslint-config": "^1.2.0",
-    "@silverhand/eslint-config-react": "^1.2.1",
+    "@silverhand/eslint-config": "workspace:^",
+    "@silverhand/eslint-config-react": "workspace:^",
     "@types/react": "^17.0.14",
     "eslint": "^8.21.0",
     "prettier": "^2.7.1",

--- a/packages/ts-config/package.json
+++ b/packages/ts-config/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/silverhand-io/configs/issues"
   },
   "devDependencies": {
-    "@silverhand/eslint-config": "^1.2.0",
+    "@silverhand/eslint-config": "workspace:^",
     "@types/eslint": "^8.4.5",
     "eslint": "^8.21.0",
     "prettier": "^2.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,7 +59,7 @@ importers:
 
   packages/eslint-config-react:
     specifiers:
-      '@silverhand/eslint-config': ^1.2.0
+      '@silverhand/eslint-config': workspace:^
       '@types/eslint': ^8.4.5
       eslint: ^8.21.0
       eslint-config-xo-react: ^0.27.0
@@ -89,8 +89,8 @@ importers:
   packages/jest-config:
     specifiers:
       '@jest/types': ^29.0.0
-      '@silverhand/eslint-config': ^1.2.0
-      '@silverhand/ts-config': ^1.2.1
+      '@silverhand/eslint-config': workspace:^
+      '@silverhand/ts-config': workspace:^
       '@types/node': '16'
       deepmerge: ^4.2.2
       identity-obj-proxy: ^3.0.0
@@ -119,7 +119,7 @@ importers:
 
   packages/ts-config:
     specifiers:
-      '@silverhand/eslint-config': ^1.2.0
+      '@silverhand/eslint-config': workspace:^
       '@types/eslint': ^8.4.5
       eslint: ^8.21.0
       prettier: ^2.7.1
@@ -133,9 +133,9 @@ importers:
 
   packages/ts-config-react:
     specifiers:
-      '@silverhand/eslint-config': ^1.2.0
-      '@silverhand/eslint-config-react': ^1.2.1
-      '@silverhand/ts-config': ^1.2.1
+      '@silverhand/eslint-config': workspace:^
+      '@silverhand/eslint-config-react': workspace:^
+      '@silverhand/ts-config': workspace:^
       '@types/react': ^17.0.14
       eslint: ^8.21.0
       prettier: ^2.7.1


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
- use `workspace:` protocol to ack changesets for dependencies
- properly link packages for version bumping

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
execute `changeset version` -> both `eslint-config` + `eslint-config-react` bump to `1.3.0`