### PR TITLE
ci: update publish flow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,24 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - '*/*@*.*.*'
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  publish-to-npm:
+    environment: npm
+    env:
+      NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTOMATION_TOKEN }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Node and pnpm
+        uses: silverhand-io/actions-node-pnpm-run-steps@v2
+
+      - name: Publish to NPM
+        run: pnpm -r publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Setup Node and pnpm
         uses: silverhand-io/actions-node-pnpm-run-steps@v2
@@ -23,6 +25,7 @@ jobs:
           passphrase: ${{ secrets.BOT_GPG_PASSPHRASE }}
           git_user_signingkey: true
           git_commit_gpgsign: true
+          git_tag_gpgsign: true
 
       - name: Configure Git user
         run: |
@@ -32,10 +35,9 @@ jobs:
       - name: Create release pull request
         uses: changesets/action@v1
         with:
-          publish: pnpm ci:publish
+          publish: changeset tag
           commit: 'release: version packages'
           title: 'release: version packages'
           setupGitUser: false
         env:
           GITHUB_TOKEN: ${{ secrets.BOT_PAT }}
-          NPM_TOKEN: ${{ secrets.NPM_AUTOMATION_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -4,9 +4,6 @@
   "devDependencies": {
     "@changesets/cli": "^2.25.0"
   },
-  "scripts": {
-    "ci:publish": "pnpm -r publish && changeset tag && git push --tags"
-  },
   "engines": {
     "node": "^16.0.0 || ^18.0.0",
     "pnpm": "^7.0.0"


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
- decouple tagging and npm publishing, now it's like:
  - merge versioning PR -> tag, create GitHub release -> publish to NPM
- caveat: `pnpm -r publish` won't fail. track in:
  - pnpm/pnpm#5528

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
after merging, try a force prerelease publish