### PR TITLE
refactor: turn off `@typescript-eslint/no-unsafe-enum-comparison`

### DIFF
--- a/.changeset/stupid-falcons-walk.md
+++ b/.changeset/stupid-falcons-walk.md
@@ -1,0 +1,5 @@
+---
+"@silverhand/eslint-config": patch
+---
+
+turn off `@typescript-eslint/no-unsafe-enum-comparison`

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -327,6 +327,8 @@ module.exports = {
           },
         ],
         '@typescript-eslint/no-explicit-any': 'error',
+        /** This brings more trouble than it solves. We have a lot of dynamic enum checks. */
+        '@typescript-eslint/no-unsafe-enum-comparison': 'off',
         /** No need as we have exhaustiveness check */
         'default-case': 'off',
       },


### PR DESCRIPTION
<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
This rule brings more trouble than it solves. We have a lot of dynamic enum checks

<!-- Optional -->
## Linear Issue Reference
<!-- If your PR is not linked to any specific linear task or breaks into multiple sub-PRs. Please list the issue reference here. -->


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
